### PR TITLE
Add Composer Scripts for Testing, Linting, and Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /public/storage
 /storage/*.key
 /storage/pail
+/storage/rector
 /vendor
 .env
 .env.backup

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.15",
+        "driftingly/rector-laravel": "^2.0",
         "fakerphp/faker": "^1.23",
         "larastan/larastan": "^3.0",
         "laravel/pail": "^1.2.2",
@@ -27,9 +28,11 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
+        "peckphp/peck": "^0.1.2",
         "pestphp/pest": "^3.7",
         "pestphp/pest-plugin-drift": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.1"
+        "pestphp/pest-plugin-laravel": "^3.1",
+        "rector/rector": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -62,6 +65,22 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+        ],
+        "test:unit": "./vendor/bin/pest --colors=always --coverage --compact --min=100",
+        "lint": "./vendor/bin/pint",
+        "refactor": "./vendor/bin/rector",
+        "test:lint": "./vendor/bin/pint --test",
+        "test:peck": "./vendor/bin/peck",
+        "test:type-coverage": "./vendor/bin/pest --type-coverage --compact --min=100",
+        "stan": "./vendor/bin/phpstan analyse --ansi",
+        "test:refactor": "rector --dry-run",
+        "test": [
+            "@test:peck",
+            "@test:refactor",
+            "@test:lint",
+            "@stan",
+            "@test:type-coverage",
+            "@test:unit"
         ]
     },
     "extra": {

--- a/peck.json
+++ b/peck.json
@@ -1,0 +1,8 @@
+{
+    "preset": "laravel",
+    "ignore": {
+        "words": ["php", "ds"],
+        "paths": []
+    }
+}
+

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\SetList;
+use Rector\ValueObject\PhpVersion;
+use RectorLaravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    // Paths to analyze
+    $rectorConfig->paths([
+        __DIR__.'/app',
+        __DIR__.'/config',
+        __DIR__.'/database',
+        __DIR__.'/resources',
+        __DIR__.'/routes',
+        __DIR__.'/tests',
+        __DIR__.'/public',
+    ]);
+
+    $rectorConfig->rules([
+        InlineConstructorDefaultToPropertyRector::class,
+    ]);
+
+    // Skip specific rules
+    $rectorConfig->skip([
+        //
+    ]);
+
+    // Enable caching for Rector
+    $rectorConfig->cacheDirectory(__DIR__.'/storage/rector');
+    $rectorConfig->cacheClass(FileCacheStorage::class);
+
+    // Apply sets for Laravel and general code quality
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        SetList::DEAD_CODE,
+        LaravelSetList::LARAVEL_CODE_QUALITY,
+        LaravelSetList::LARAVEL_COLLECTION,
+        LaravelSetList::LARAVEL_LEGACY_FACTORIES_TO_CLASSES,
+        SetList::EARLY_RETURN,
+        SetList::STRICT_BOOLEANS,
+        SetList::TYPE_DECLARATION,
+    ]);
+
+    // Define PHP version for Rector
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
+};


### PR DESCRIPTION
## Description
This PR adds several scripts to `composer.json` to facilitate unit testing, linting, refactoring, and static code analysis in the project.

## **Changes Made:**
- Added `test:unit` to run tests with Pest, ensuring 100% coverage.
- Added `lint` to run Pint and maintain properly formatted code.
- Added `refactor` to run Rector and enable automatic refactoring.
- Added `test:lint` to verify if the code follows formatting rules without modifying it.
- Added `test:peck` to run Peck and validate type correctness in the code.
- Added `test:type-coverage` to check type coverage with Pest.
- Added `stan` to run PHPStan for static code analysis.
- Added `test:refactor` to execute Rector in `--dry-run` mode and check recommended changes.
- Created a `test` script that groups all the above checks for easy execution.

## **Motivation:**
These changes standardize and automate the code validation process, ensuring quality and consistency in project development. By consolidating all checks into a single command (`composer test`), it simplifies integration into CI/CD pipelines and local execution for developers.

## **Steps to Test:**
1. Run `composer install` to ensure all tools are installed, or maybe `composer update`, not really sure.
2. Run `composer test` to verify that all checks execute correctly.

