### PR TITLE
fix: replaced bloated subscription fetching with a vibe coded one-liner

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,16 +73,7 @@ class User extends Authenticatable
 
     public function getHighestSubscription(): TwitchSubscription
     {
-        $subscription = UserTwitchSubscription::where('user_id', $this->id)
-            ->where('twitch_subscription', '>=', TwitchSubscription::Tier1)
-            ->where(function ($query) {
-                $query->whereIn('broadcaster_id', config('services.twitch.friend_ids'))
-                    ->orWhere('broadcaster_id', config('services.twitch.broadcaster_id'));
-            })
-            ->orderBy('twitch_subscription', 'desc')
-            ->first();
-
-        return $subscription?->twitch_subscription ?? TwitchSubscription::None;
+        return UserTwitchSubscription::where('user_id', $this->id)->max('twitch_subscription');
     }
 
     public function canSubmitQuestion(): bool


### PR DESCRIPTION
We know for a fact that the user twitch subscription is only filled with the subscription status of the user in all of the admin channels, so max will return the highest twitch subscription, and if the user has none it will return none by contruction. [I watched @tjdevries 's stream]

If this assumption is ever broken we can add a where clause to assert the `broadcaster_id` is in the `User::getAllFriendIDs()`

`->whereIn('broadcaster_id', User::getAllFriendIDs())`



and no this wasn't vibe coded